### PR TITLE
refactor(webhook-receiver): Partially Complete Refactor

### DIFF
--- a/Flipdish.Recruiting.WebhookReceiver/EmailRenderer.cs
+++ b/Flipdish.Recruiting.WebhookReceiver/EmailRenderer.cs
@@ -44,7 +44,7 @@ namespace Flipdish.Recruiting.WebhookReceiver
 
             string domain = SettingsService.Flipdish_DomainWithScheme;
             int orderId = _order.OrderId.Value;
-            string mapUrl = String.Empty;
+            string mapUrl = string.Empty;
             string staticMapUrl = String.Empty;
             double? airDistance = null;
             string supportNumber = SettingsService.RestaurantSupportNumber;
@@ -464,33 +464,33 @@ namespace Flipdish.Recruiting.WebhookReceiver
             }
         }
 
-        private string GetLineDivider()
-        {
-            StringBuilder result = new StringBuilder();
+        //private string GetLineDivider()
+        //{
+        //    StringBuilder result = new StringBuilder();
 
-            result.AppendLine("<tr>");
-            result.AppendLine("<td colspan=\"2\" align =\"center\" valign=\"top\">");
-            result.AppendLine("<table width=\"100%\" border=\"0\" cellspacing=\"0\" cellpadding=\"0\" align=\"center\" style=\"height: 1px; background-color: rgb(186, 186, 186);\">");
-            result.AppendLine("</table>");
-            result.AppendLine("</td>");
-            result.AppendLine("</tr>");
+        //    result.AppendLine("<tr>");
+        //    result.AppendLine("<td colspan=\"2\" align =\"center\" valign=\"top\">");
+        //    result.AppendLine("<table width=\"100%\" border=\"0\" cellspacing=\"0\" cellpadding=\"0\" align=\"center\" style=\"height: 1px; background-color: rgb(186, 186, 186);\">");
+        //    result.AppendLine("</table>");
+        //    result.AppendLine("</td>");
+        //    result.AppendLine("</tr>");
 
-            return result.ToString();
-        }
+        //    return result.ToString();
+        //}
 
-        private string GetSpaceDivider()
-        {
-            StringBuilder result = new StringBuilder();
+        //private string GetSpaceDivider()
+        //{
+        //    StringBuilder result = new StringBuilder();
 
-            result.AppendLine("<tr>");
-            result.AppendLine("<td colspan=\"2\" align =\"center\" valign=\"top\">");
-            result.AppendLine("<table width=\"100%\" border=\"0\" cellspacing=\"0\" cellpadding=\"0\" align=\"center\" style=\"height: 22px;\">");
-            result.AppendLine("</table>");
-            result.AppendLine("</td>");
-            result.AppendLine("</tr>");
+        //    result.AppendLine("<tr>");
+        //    result.AppendLine("<td colspan=\"2\" align =\"center\" valign=\"top\">");
+        //    result.AppendLine("<table width=\"100%\" border=\"0\" cellspacing=\"0\" cellpadding=\"0\" align=\"center\" style=\"height: 22px;\">");
+        //    result.AppendLine("</table>");
+        //    result.AppendLine("</td>");
+        //    result.AppendLine("</tr>");
 
-            return result.ToString();
-        }
+        //    return result.ToString();
+        //}
 
         public void Dispose()
         {

--- a/Flipdish.Recruiting.WebhookReceiver/LiquidTemplates/ItemsPartial.liquid
+++ b/Flipdish.Recruiting.WebhookReceiver/LiquidTemplates/ItemsPartial.liquid
@@ -29,7 +29,7 @@
 				<tr>
 					<td cellpadding="2px" valign="middle" style="padding-left: 40px;padding-top: 10px; padding-bottom:10px">+ {{ option.Name }}</td>
 					<td cellpadding="2px" valign="middle">{{ option.Price }}</td>
-					{% if item.MenuItemUI.Barcode %}
+					{% if option.Barcode %}
 						<td cellpadding="2px" valign="middle">
 							<img style="margin-left: 14px;margin-left: 9px;padding-top: 10px; padding-bottom:10px" src="cid:{{ option.Barcode }}.png"/>
 						</td>

--- a/Flipdish.Recruiting.WebhookReceiver/LiquidTemplates/ItemsPartial.liquid
+++ b/Flipdish.Recruiting.WebhookReceiver/LiquidTemplates/ItemsPartial.liquid
@@ -1,0 +1,42 @@
+﻿<table>
+	<tr>
+		<td cellpadding="2px" valign="top" style="font-weight: bold;">Order items</td>
+		<td cellpadding="2px" valign="top"></td>
+	</tr>
+	{% render "SpaceDividerPartial" %}
+	{% for section in sectionsGrouped %}
+		<tr>
+			<td cellpadding="2px" valign="top" style="font-size: 14px;">{{ section.Name }}</td>
+			<td cellpadding="2px" valign="top" style="font-size: 14px;"></td>
+		</tr>
+		{% render "LineDividerPartial" %}
+		{% render "SpaceDividerPartial" %}
+		{% for item in section.MenuItemsGroupedList %}
+			<tr>
+				<td cellpadding="2px" valign="middle" style="padding-left: 40px;">{{ item.Count }}{item.MenuItemUI.Name}</td>
+				<td cellpadding="2px" valign="middle">{{ item.Price }}</td>
+				{% if item.MenuItemUI.Barcode %}
+					<td cellpadding="2px" valign="middle">
+						<img style="margin-left: 14px;margin-left: 9px;padding-top: 10px; padding-bottom:10px" src="cid:{{ item.MenuItemUI.Barcode }}.png"/>
+					</td>
+				{% endif %}
+				{% if item.Count > 1 %}
+					<td cellpadding="2px" valign="middle" style="font-size:40px">x</td>
+					<td cellpadding="2px" valign="middle" style="font-size:50px">{item.Count}</td>
+				{% endif %}
+			</tr>
+			{% for option in item.MenuItemUI.MenuOptions %}
+				<tr>
+					<td cellpadding="2px" valign="middle" style="padding-left: 40px;padding-top: 10px; padding-bottom:10px">+ {{ option.Name }}</td>
+					<td cellpadding="2px" valign="middle">{{ option.Price }}</td>
+					{% if item.MenuItemUI.Barcode %}
+						<td cellpadding="2px" valign="middle">
+							<img style="margin-left: 14px;margin-left: 9px;padding-top: 10px; padding-bottom:10px" src="cid:{{ option.Barcode }}.png"/>
+						</td>
+					{% endif %}
+				</tr>
+			{% endfor %}
+		{% endfor %}
+		{% render "SpaceDividerPartial" %}
+	{% endfor %}
+</table>

--- a/Flipdish.Recruiting.WebhookReceiver/LiquidTemplates/LineDividerPartial.liquid
+++ b/Flipdish.Recruiting.WebhookReceiver/LiquidTemplates/LineDividerPartial.liquid
@@ -1,0 +1,6 @@
+﻿<tr>
+	<td colspan="2" align ="center" valign="top">
+		<table width="100%" border="0" cellspacing="0" cellpadding="0" align="center" style="height: 1px; background-color: rgb(186, 186, 186);">
+		</table>
+	</td>
+</tr>

--- a/Flipdish.Recruiting.WebhookReceiver/LiquidTemplates/SpaceDividerPartial.liquid
+++ b/Flipdish.Recruiting.WebhookReceiver/LiquidTemplates/SpaceDividerPartial.liquid
@@ -1,0 +1,6 @@
+﻿<tr>
+	<td colspan="2" align ="center" valign="top">
+		<table width="100%" border="0" cellspacing="0" cellpadding="0" align="center" style="height: 22px;">
+		</table>
+	</td>
+</tr>


### PR DESCRIPTION
The work in this PR took around 2.5 to 3 hours.

Flipdish.Recruiting.WebhookReceiver/WebhookReceiver.cs has been simplified - removing business logic and testing logic so that it can act as a thin wrapper that calls the underlying service.

Flipdish.Recruiting.WebhookReceiver/EmailRenderer.cs has had the view logic removed and put into a new liquid template so that it can focus on preparing the data and handing it over to the view engine (Liquid) to do the actual rendering rather than building the string itself.

I would have liked to improve Flipdish.Recruiting.WebhookReceiver/EmailService.cs - the way that it interacts with EmailRenderer and is called by WebhookReceiver.

I would have liked to create a unit test project and written tests.

I would have liked to move the models into their own project - especially as they are auto generated by OpenAPI / Swagger.

There are many improvements I would have liked to make in and around the Helpers.